### PR TITLE
Fix #27: Allow password reset

### DIFF
--- a/app/FrontendModule/components/LoginForm/LoginFormComponent.php
+++ b/app/FrontendModule/components/LoginForm/LoginFormComponent.php
@@ -1,47 +1,95 @@
 <?php
+
+use Nette\Mail\IMailer;
 use Tracy\Debugger;
 
 class LoginFormComponent extends BaseComponent
 {
+	private $mailParams;
+
+	/** @var IMailer */
+	private $mailer;
+
+	public function __construct(IMailer $mailer) {
+		parent::__construct();
+		$this->mailer = $mailer;
+	}
+
+	public function setMailParameters($params) {
+		$this->mailParams = $params;
+	}
 
 	public function formSubmitted(Nette\Forms\Form $form) {
-	$values = $form->getValues();
+		$values = $form->getValues();
 
-	try {
-		Interlos::getUser()->login($values['name'], $values['password']);
-	}
-	catch(Nette\Security\AuthenticationException $e) {
-		if ($e->getCode() == Nette\Security\IAuthenticator::IDENTITY_NOT_FOUND) {
-		$this->getPresenter()->flashMessage("Daný tým neexistuje.", "error");
+		if ($form['reset']->isSubmittedBy()) {
+			$row = Interlos::teams()->findAll()->where("[name] = %s", $values['name'])->fetch();
+			if (!$row) {
+				$this->getPresenter()->flashMessage("Daný tým neexistuje.", "error");
+				return;
+			}
+			// Insert team
+			$code = sha1(\Nette\Utils\Random::generate(160));
+			Interlos::teams()->update(['reset_code' => $code])->where("[id_team] = %i", $row->id_team)->execute();
+			// Send e-mail
+			/** @var \Nette\Bridges\ApplicationLatte\Template $template */
+			$template = InterlosTemplate::loadTemplate($this->createTemplate());
+			$template->getLatte()->addFilter(null, 'Nette\Templating\Helpers::loader');
+			$template->setFile(__DIR__ . "/../../templates/mail/resetPassword.latte");
+			$template->team = $values['name'];
+			$template->id = $row->id_team;
+			$template->code = $code;
+			$mail = new Nette\Mail\Message();
+			$mail->setHtmlBody($template->renderToString());
+			$mail->addTo($row->email);
+			$mail->setFrom($this->mailParams['info'], $this->mailParams['name']);
+			$mail->setSubject("Interlos - žádost o změnu hesla");
+			$this->mailer->send($mail);
+
+			$this->getPresenter()->flashMessage("Týmu '".$row->name."' byl úspěšně zaslán e-mail s instrukcemi pro změnu hesla.", "success");
+			$this->getPresenter()->redirect("this");
+			return;
 		}
-		else {
-		$this->getPresenter()->flashMessage("Nesprávné heslo", "error");
+
+		try {
+			Interlos::getUser()->login($values['name'], $values['password']);
 		}
-		return;
-	}
-	catch(Exception $e) {
-		$this->getPresenter()->flashMessage("Stala se neočekávaná chyba.", "error");
-		Debugger::log($e, Debugger::EXCEPTION);
-		return;
-	}
-	$this->getPresenter()->redirect("Team:default");
+		catch(Nette\Security\AuthenticationException $e) {
+			if ($e->getCode() == Nette\Security\IAuthenticator::IDENTITY_NOT_FOUND) {
+			$this->getPresenter()->flashMessage("Daný tým neexistuje.", "error");
+			}
+			else {
+			$this->getPresenter()->flashMessage("Nesprávné heslo", "error");
+			}
+			return;
+		}
+		catch(Exception $e) {
+			$this->getPresenter()->flashMessage("Stala se neočekávaná chyba.", "error");
+			Debugger::log($e, Debugger::EXCEPTION);
+			return;
+		}
+		$this->getPresenter()->redirect("Team:default");
 	}
 
 	// ---- PROTECTED METHODS
 
 	protected function createComponentForm($name) {
-	$form = new BaseForm($this, $name);
+		$form = new BaseForm($this, $name);
 
-	$form->addText("name", "Název týmu")
-		->addRule(Nette\Forms\Form::FILLED, "Název týmu musí být vyplněn.");
+		$nameField = $form->addText("name", "Název týmu");
+		$nameField
+			->addRule(Nette\Forms\Form::FILLED, "Název týmu musí být vyplněn.");
 
-	$form->addPassword("password", "Heslo")
-		->addRule(Nette\Forms\Form::FILLED, "Heslo musí být vyplněno.");
+		$form->addPassword("password", "Heslo")
+			->addRule(Nette\Forms\Form::FILLED, "Heslo musí být vyplněno.");
 
-	$form->addSubmit("login", "Přihlásit se");
-	$form->onSuccess[] = array($this, "formSubmitted");
+		$form->addReCaptcha('recaptcha', $label = 'Ochrana před spamboty', $required = TRUE, $message = 'Jste živý člověk?');
+		$form->addSubmit("login", "Přihlásit se");
+		$form->addSubmit("reset", "Resetovat heslo")
+			->setValidationScope([$nameField]);
+		$form->onSuccess[] = array($this, "formSubmitted");
 
-	return $form;
+		return $form;
 	}
 
 }

--- a/app/FrontendModule/components/ResetPasswordForm/ResetPasswordFormComponent.php
+++ b/app/FrontendModule/components/ResetPasswordForm/ResetPasswordFormComponent.php
@@ -1,0 +1,62 @@
+<?php
+
+class ResetPasswordFormComponent extends BaseComponent
+{
+	private $codeFromUrl;
+
+	private $nameFromUrl;
+
+	public function __construct($codeFromUrl, $nameFromUrl)
+	{
+		parent::__construct();
+		$this->codeFromUrl = $codeFromUrl;
+		$this->nameFromUrl = $nameFromUrl;
+	}
+
+	public function formSubmitted(Nette\Forms\Form $form) {
+		$values = $form->getValues();
+
+
+		$row = Interlos::teams()->findAll()->where("[name] = %s AND [reset_code] IS NOT NULL AND [reset_code] = %s", $values['name'], $values['code'])->fetch();
+		if (!$row) {
+			$this->getPresenter()->flashMessage("Daný tým neexistuje nebo je kód pro obnovu hesla již neplatný.", "error");
+			return;
+		}
+
+		Interlos::teams()->update(['reset_code' => null, 'password' => TeamAuthenticator::passwordHash($values['password'])])->where("[id_team] = %i", $row->id_team)->execute();
+		$this->getPresenter()->flashMessage("Týmu '".$row->name."' bylo úspěšně změněho heslo a byl rovnou přihlášen.", "success");
+		Interlos::getUser()->login($values['name'], $values['password']);
+		$this->getPresenter()->redirect("Team:default");
+	}
+
+	// ---- PROTECTED METHODS
+
+	protected function createComponentForm($name) {
+		$form = new BaseForm($this, $name);
+
+		$nameField = $form->addText("name", "Název týmu");
+		$nameField
+			->setRequired(true)
+			->addRule(Nette\Forms\Form::FILLED, "Název týmu musí být vyplněn.");
+
+		$form->addText('code', 'Kód')
+			->setRequired(true)
+			->addRule(\Nette\Forms\Form::FILLED, 'Kód pro obnovu hesla musí být vyplněn.');
+
+		$form->addPassword("password", "Heslo")
+			->setRequired(true)
+			->addRule(Nette\Forms\Form::FILLED, "Heslo musí být vyplněno.");
+		$form->addPassword("password2", "Heslo pro kontrolu")
+			->setRequired(true)
+			->addRule(Nette\Forms\Form::FILLED, "Heslo pro kontrolu musí být vyplněno.")
+			->addRule(\Nette\Forms\Form::EQUAL, 'Hesla se musí shodovat', $form['password']);
+
+		$form->addReCaptcha('recaptcha', $label = 'Ochrana před spamboty', $required = TRUE, $message = 'Jste živý člověk?');
+		$form->addSubmit("reset", "Nastavit nové heslo");
+		$form->onSuccess[] = array($this, "formSubmitted");
+		$form->setDefaults(['code' => $this->codeFromUrl, 'name' => $this->nameFromUrl]);
+
+	return $form;
+	}
+
+}

--- a/app/FrontendModule/components/ResetPasswordForm/resetPasswordForm.latte
+++ b/app/FrontendModule/components/ResetPasswordForm/resetPasswordForm.latte
@@ -1,0 +1,1 @@
+{control form}

--- a/app/FrontendModule/presenters/DefaultPresenter.php
+++ b/app/FrontendModule/presenters/DefaultPresenter.php
@@ -2,12 +2,14 @@
 namespace FrontModule;
 
 use Nette\Application\BadRequestException;
+use Nette\Mail\IMailer;
 use Nette\Security\AuthenticationException;
 
 class DefaultPresenter extends BasePresenter {
 
 	public function actionLogout() {
 		$this->user->logout(TRUE);
+		\Interlos::cleanPasswordResetTokens();
 		$this->redirect("default");
 	}
 
@@ -25,7 +27,13 @@ class DefaultPresenter extends BasePresenter {
 	}
 
 	public function renderLogin() {
+		\Interlos::cleanPasswordResetTokens();
 		$this->setPagetitle("Přihlásit se");
+	}
+
+	public function renderResetPassword($code = '') {
+		\Interlos::cleanPasswordResetTokens();
+		$this->setPagetitle("Změna hesla");
 	}
 
 	// ----- PROTECTED METHODS
@@ -36,7 +44,14 @@ class DefaultPresenter extends BasePresenter {
 	}
 
 	protected function createComponentLogin($name) {
-		return new \LoginFormComponent();
+		$comp = new \LoginFormComponent($this->context->getByType(IMailer::class));
+		$comp->setMailParameters($this->context->parameters['mail']);
+		return $comp;
+	}
+
+	protected function createComponentResetPassword($name) {
+		$comp = new \ResetPasswordFormComponent($this->getParameter('code'), $this->getParameter('name'));
+		return $comp;
 	}
 
 }

--- a/app/FrontendModule/templates/Default/resetPassword.latte
+++ b/app/FrontendModule/templates/Default/resetPassword.latte
@@ -1,7 +1,7 @@
 {block #content}
 	<div class="main-block">
-		<h1 class="center">Přihlášení týmu</h1>
-		{control login}
+		<h1 class="center">Změna hesla</h1>
+		{control resetPassword}
 	</div>
 {/block}
 

--- a/app/FrontendModule/templates/mail/resetPassword.latte
+++ b/app/FrontendModule/templates/mail/resetPassword.latte
@@ -1,0 +1,8 @@
+<p>Ahoj,</p>
+
+<p>někdo požádal o z měnu hesla týmu <strong>{$team}</strong> (ID: {$id}) na stránkách <a href="https://interlos.fi.muni.cz">https://interlos.fi.muni.cz</a>. Změnu hesla můžete pomocí kódu {$code} dokončit na adrese <a href="https://interlos.fi.muni.cz/default/reset-password?code={$code}&name={$team}">https://interlos.fi.muni.cz/default/reset-password</a></p>
+
+<p>
+S pozdravem,<br />
+InterLoSí tým
+</p>

--- a/app/model/Interlos.php
+++ b/app/model/Interlos.php
@@ -315,4 +315,8 @@ class Interlos {
 		return self::$container->getByType(\Nette\Http\Session::class)->getSection($namespace);
 	}
 
+	public static function cleanPasswordResetTokens() {
+		self::teams()->update(['reset_code' => null])->where("[reset_code] IS NOT NULL AND updated < DATE_SUB(NOW(),INTERVAL 2 DAY)")->execute();
+	}
+
 }

--- a/resources/db/tables.sql
+++ b/resources/db/tables.sql
@@ -108,6 +108,7 @@ CREATE TABLE `team` (
 	`email` varchar(150) COLLATE utf8_czech_ci DEFAULT NULL COMMENT 'e-mailova adresa',
 	`inserted` datetime NOT NULL COMMENT 'cas, kdy byla polozka vlozena do systemu',
 	`updated` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT 'cas, kdy byla polozka naposledy zmenena',
+    `reset_code` varchar(160) COLLATE utf8_czech_ci NULL COMMENT 'password reset code',
 	PRIMARY KEY (`id_team`),
 	UNIQUE KEY `id_year` (`id_year`,`name`),
 	UNIQUE KEY `id_year_2` (`id_year`,`email`),

--- a/resources/db/views.sql
+++ b/resources/db/views.sql
@@ -15,6 +15,7 @@ CREATE VIEW `view_team` AS
 			`team`.`category`,
 			`team`.`email`,
 			`team`.`inserted`,
+			`team`.`reset_code`,
 			CAST(COALESCE (`team`.`updated`, `team`.`inserted`) AS DATETIME) AS `updated` -- This bypass the problematic default value in views (zeros instead of CURRENT_TIMESTAMP) which causes problem on temporary table creation
 		FROM `team`
 		INNER JOIN `view_current_year` USING(`id_year`)


### PR DESCRIPTION
Please test the overall proces and try to break it as it was code in very fast manner (1h 20m).

Saved one form by adding additional button to login form, also teams forget their e-mails so the name is the safest option from remembering point of view, however this would create batch attacts as team name is public information and therefore I added captcha even on login form (and also on new password change form).